### PR TITLE
Fixes for tls, grafana variable syntax, victoriametrics and the check_nwc_health-interface.php template

### DIFF
--- a/histou/database/jsondatabase.php
+++ b/histou/database/jsondatabase.php
@@ -69,7 +69,13 @@ abstract class JSONDatabase
     protected function makeGetRequest($query)
     {
         try {
-            $content = file_get_contents($this->url.urlencode($query));
+            $contextOptions = array(
+                'ssl' => array(
+                    'verify_peer'   => false,
+                )
+            );
+            $context = stream_context_create($contextOptions);
+            $content = file_get_contents($this->url.urlencode($query), false, $context);
         } catch (\ErrorException $e) {
             return $e->getMessage();
         }

--- a/histou/grafana/dashboard/dashboardinfluxdb.php
+++ b/histou/grafana/dashboard/dashboardinfluxdb.php
@@ -87,6 +87,6 @@ class DashboardInfluxDB extends Dashboard
 
     public function genTemplateVariable($variable)
     {
-        return "[[$variable]]";
+        return "\${". $variable .":raw}";
     }
 }

--- a/histou/grafana/dashboard/dashboardvictoriametrics.php
+++ b/histou/grafana/dashboard/dashboardvictoriametrics.php
@@ -57,6 +57,6 @@ class DashboardVictoriametrics extends Dashboard
     **/
     public function genTemplateVariable($variable)
     {
-        return "\$$variable";
+        return "\${". $variable .":raw}";
     }
 }

--- a/histou/grafana/dashboard/dashboardvictoriametrics.php
+++ b/histou/grafana/dashboard/dashboardvictoriametrics.php
@@ -48,7 +48,7 @@ class DashboardVictoriametrics extends Dashboard
 
     public function addTemplateForPerformanceLabel($name, $host, $service, $regex = '', $multiFormat = false, $includeAll = false)
     {
-        $query = sprintf('{"find": "terms", "field": "performanceLabel", "query": "host: %s, service: %s"}', $host, $service);
+        $query = sprintf('label_values(metrics_value{host="%s", service="%s"},performanceLabel)', $host, $service);
         $this->addTemplate(VICTORIAMETRICS_DS, $name, $query, $regex, $multiFormat, $includeAll);
     }
 

--- a/templates/default/check_nwc_health-interface.php
+++ b/templates/default/check_nwc_health-interface.php
@@ -19,7 +19,6 @@ $rule = new \histou\template\Rule(
 $genTemplate = function ($perfData) {
     $dashboard = \histou\grafana\dashboard\DashboardFactory::generateDashboard($perfData['host'].'-'.$perfData['service']);
     $dashboard->addDefaultAnnotations($perfData['host'], $perfData['service']);
-    $templeQuery = 'SHOW TAG VALUES WITH KEY = "performanceLabel" WHERE "host" = \''.$perfData['host'].'\' AND "service" = \''.$perfData['service'].'\'';
     $templateName = 'Interface';
     $dashboard->addTemplateForPerformanceLabel(
         $templateName,

--- a/templates/default/check_nwc_health-interface.php
+++ b/templates/default/check_nwc_health-interface.php
@@ -55,7 +55,7 @@ $genTemplate = function ($perfData) {
                     return 4;
             }
         };
-        return ($index($firstLabel) - $index($secondLabel)) ? -1 : 1;
+        return ($index($firstLabel) < $index($secondLabel)) ? -1 : 1;
     });
     $row = new \histou\grafana\Row($perfData['service'].' '.$perfData['command']);
     $numberPanels = 0;

--- a/templates/default/check_nwc_health-interface.php
+++ b/templates/default/check_nwc_health-interface.php
@@ -25,7 +25,7 @@ $genTemplate = function ($perfData) {
         $templateName,
         $perfData['host'],
         $perfData['service'],
-        $regex = '^(.*?)_([a-zA-Z]+?)_[a-zA-Z]+$',
+        $regex = '^(.*?)(_broadcast|)_([a-zA-Z]+?)_[a-zA-Z]+$', //ignore broadcast_usage_in and _out for now
         $multiFormat = true,
         $includeAll = false
     );


### PR DESCRIPTION
This patch skips TLS checks to the database, to prevent this error:

![histou_victoriametrics_ssl_error](https://github.com/user-attachments/assets/3c5addf3-9eb6-46e7-8fd7-493053fadc47)
