### PR TITLE
escape performanceLabel to fix lookup errors

### DIFF
--- a/histou/grafana/graphpanel/graphpanelvictoriametrics.php
+++ b/histou/grafana/graphpanel/graphpanelvictoriametrics.php
@@ -59,6 +59,9 @@ class GraphPanelVictoriametrics extends GraphPanel
         if ($alias == '') {
             $alias = $performanceLabel;
         }
+
+        $performanceLabel = addslashes($performanceLabel);
+
         if ($useRegex) {
             $target = $this->createTarget(array(
                                             'host' => array('value' => "^".$host."$", 'operator' => '=~'),
@@ -137,6 +140,9 @@ class GraphPanelVictoriametrics extends GraphPanel
         if ($alias == '') {
             $alias = 'downtime';
         }
+
+        $performanceLabel = addslashes($performanceLabel);
+
         if ($useRegex) {
             $target = $this->createTarget(
                 array(

--- a/histou/grafana/graphpanel/graphpanelvictoriametricstarget.php
+++ b/histou/grafana/graphpanel/graphpanelvictoriametricstarget.php
@@ -34,7 +34,7 @@ class GraphPanelVictoriametricsTarget extends \ArrayObject implements \JsonSeria
 
     private function getExpr()
     {
-        $expr =  'last_over_time({__name__=~"' . $this['measurement'] . "_(" . $this->getSelect() . ')",' . $this->getFilter() . '}[15m])';
+        $expr =  'last_over_time({__name__=~"' . $this['measurement'] . "_(" . $this->getSelect() . ')",' . $this->getFilter() . '})';
         return 'label_replace(' . $expr . ', "__tmp_alias", "$1", "__name__", "metrics_(.*)")';
     }
 


### PR DESCRIPTION
We have some historical SNMP check data in the Victoriametrics database, which is generating a Grafana error.

Before the fix:
<img width="911" height="419" alt="grafik" src="https://github.com/user-attachments/assets/9d61afb1-3666-4b7c-be9a-3c9f0a952a7e" />

After the fix:
<img width="912" height="425" alt="grafik" src="https://github.com/user-attachments/assets/45fb088f-ddf0-466b-8532-9736da8c672c" />
