### PR TITLE
To prevent unexpected gaps in the graph remove the lookbehind window

### DIFF
--- a/histou/grafana/graphpanel/graphpanelvictoriametricstarget.php
+++ b/histou/grafana/graphpanel/graphpanelvictoriametricstarget.php
@@ -34,7 +34,7 @@ class GraphPanelVictoriametricsTarget extends \ArrayObject implements \JsonSeria
 
     private function getExpr()
     {
-        $expr =  'last_over_time({__name__=~"' . $this['measurement'] . "_(" . $this->getSelect() . ')",' . $this->getFilter() . '}[15m])';
+        $expr =  'last_over_time({__name__=~"' . $this['measurement'] . "_(" . $this->getSelect() . ')",' . $this->getFilter() . '})';
         return 'label_replace(' . $expr . ', "__tmp_alias", "$1", "__name__", "metrics_(.*)")';
     }
 


### PR DESCRIPTION
Currently, the Victoriametrics lookbehind window is fixed at 15 minutes. If we have a timeseries with an hourly interval, there will be gaps in the Grafana graph.
If omitted, VictoriaMetrics automatically selects the lookbehind window. See https://docs.victoriametrics.com/victoriametrics/metricsql/#metricsql-features for more information.

original behavior:
<img width="1158" height="387" alt="grafik" src="https://github.com/user-attachments/assets/610888f9-69f7-42e7-8aff-568b606d98df" />

with the fix:
<img width="942" height="388" alt="grafik" src="https://github.com/user-attachments/assets/b57ba618-c97a-4753-be4f-440dce578b3c" />
